### PR TITLE
feat(weather-fetcher): Add support for fetching weather data for all …

### DIFF
--- a/data/all_current_weather.json
+++ b/data/all_current_weather.json
@@ -1,0 +1,704 @@
+{
+    "Bydgoszcz": {
+        "latitude": 53.12,
+        "longitude": 17.999998,
+        "generationtime_ms": 0.04506111145019531,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 41.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 1.9,
+            "windspeed": 6.1,
+            "winddirection": 320,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Czestochowa": {
+        "latitude": 50.800873,
+        "longitude": 19.126526,
+        "generationtime_ms": 0.053048133850097656,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 251.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 0.9,
+            "windspeed": 10.1,
+            "winddirection": 314,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Daugavpils": {
+        "latitude": 55.87606,
+        "longitude": 26.52974,
+        "generationtime_ms": 1.1299848556518555,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 106.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": -0.6,
+            "windspeed": 12.2,
+            "winddirection": 332,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Gdansk": {
+        "latitude": 54.36,
+        "longitude": 18.64,
+        "generationtime_ms": 0.049948692321777344,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 9.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 4.0,
+            "windspeed": 6.6,
+            "winddirection": 315,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Gniezno": {
+        "latitude": 52.54,
+        "longitude": 17.58,
+        "generationtime_ms": 0.054001808166503906,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 122.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 0.9,
+            "windspeed": 11.3,
+            "winddirection": 333,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Gorzow Wielkopolski": {
+        "latitude": 52.739998,
+        "longitude": 15.219999,
+        "generationtime_ms": 0.08296966552734375,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 37.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 0.6,
+            "windspeed": 7.6,
+            "winddirection": 341,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Grudziadz": {
+        "latitude": 53.48,
+        "longitude": 18.759998,
+        "generationtime_ms": 0.04303455352783203,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 25.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 1.9,
+            "windspeed": 4.8,
+            "winddirection": 283,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Krakow": {
+        "latitude": 50.057274,
+        "longitude": 19.949356,
+        "generationtime_ms": 0.05602836608886719,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 215.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 0.8,
+            "windspeed": 8.3,
+            "winddirection": 255,
+            "is_day": 0,
+            "weathercode": 51
+        }
+    },
+    "Krosno": {
+        "latitude": 49.697346,
+        "longitude": 21.76773,
+        "generationtime_ms": 0.051021575927734375,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 279.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": -0.1,
+            "windspeed": 13.3,
+            "winddirection": 298,
+            "is_day": 0,
+            "weathercode": 51
+        }
+    },
+    "Landshut": {
+        "latitude": 48.54,
+        "longitude": 12.139999,
+        "generationtime_ms": 0.049948692321777344,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 392.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 0.8,
+            "windspeed": 2.5,
+            "winddirection": 360,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Leszno": {
+        "latitude": 51.84,
+        "longitude": 16.58,
+        "generationtime_ms": 0.16999244689941406,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 96.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 1.2,
+            "windspeed": 8.4,
+            "winddirection": 310,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Lublin": {
+        "latitude": 51.243538,
+        "longitude": 22.551773,
+        "generationtime_ms": 0.041961669921875,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 197.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 0.9,
+            "windspeed": 13.0,
+            "winddirection": 299,
+            "is_day": 0,
+            "weathercode": 51
+        }
+    },
+    "Lodz": {
+        "latitude": 51.764503,
+        "longitude": 19.453964,
+        "generationtime_ms": 0.09691715240478516,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 211.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 1.4,
+            "windspeed": 10.8,
+            "winddirection": 320,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Opole": {
+        "latitude": 50.68,
+        "longitude": 17.919998,
+        "generationtime_ms": 0.07605552673339844,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 150.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 1.4,
+            "windspeed": 9.6,
+            "winddirection": 304,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Ostrow Wielkopolski": {
+        "latitude": 51.66,
+        "longitude": 17.8,
+        "generationtime_ms": 0.04494190216064453,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 132.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 1.0,
+            "windspeed": 7.6,
+            "winddirection": 295,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Pila": {
+        "latitude": 53.16,
+        "longitude": 16.74,
+        "generationtime_ms": 0.06902217864990234,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 62.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 1.9,
+            "windspeed": 5.2,
+            "winddirection": 326,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Poznan": {
+        "latitude": 52.4,
+        "longitude": 16.919998,
+        "generationtime_ms": 0.05900859832763672,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 83.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 0.9,
+            "windspeed": 8.9,
+            "winddirection": 328,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Rawicz": {
+        "latitude": 51.6,
+        "longitude": 16.859999,
+        "generationtime_ms": 0.03802776336669922,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 101.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 1.2,
+            "windspeed": 9.4,
+            "winddirection": 302,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Rybnik": {
+        "latitude": 50.1,
+        "longitude": 18.539999,
+        "generationtime_ms": 0.03910064697265625,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 235.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 0.4,
+            "windspeed": 6.3,
+            "winddirection": 301,
+            "is_day": 0,
+            "weathercode": 77
+        }
+    },
+    "Rzeszow": {
+        "latitude": 50.03909,
+        "longitude": 22.010834,
+        "generationtime_ms": 0.06091594696044922,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 213.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 0.6,
+            "windspeed": 13.3,
+            "winddirection": 291,
+            "is_day": 0,
+            "weathercode": 73
+        }
+    },
+    "Swietochlowice": {
+        "latitude": 50.29276,
+        "longitude": 18.920944,
+        "generationtime_ms": 0.07009506225585938,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 289.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 1.0,
+            "windspeed": 9.0,
+            "winddirection": 301,
+            "is_day": 0,
+            "weathercode": 51
+        }
+    },
+    "Tarnow": {
+        "latitude": 50.02128,
+        "longitude": 20.988861,
+        "generationtime_ms": 0.1310110092163086,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 215.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 0.4,
+            "windspeed": 12.6,
+            "winddirection": 281,
+            "is_day": 0,
+            "weathercode": 73
+        }
+    },
+    "Torun": {
+        "latitude": 53.02,
+        "longitude": 18.599998,
+        "generationtime_ms": 0.047087669372558594,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 55.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 1.7,
+            "windspeed": 5.9,
+            "winddirection": 313,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Warsaw": {
+        "latitude": 52.23009,
+        "longitude": 21.017075,
+        "generationtime_ms": 0.03802776336669922,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 113.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 2.0,
+            "windspeed": 10.8,
+            "winddirection": 322,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Wroclaw": {
+        "latitude": 51.1,
+        "longitude": 17.039999,
+        "generationtime_ms": 0.04506111145019531,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 127.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 1.4,
+            "windspeed": 9.4,
+            "winddirection": 310,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    },
+    "Zielona Gora": {
+        "latitude": 51.940002,
+        "longitude": 15.499998,
+        "generationtime_ms": 0.03600120544433594,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 147.0,
+        "current_weather_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature": "°C",
+            "windspeed": "km/h",
+            "winddirection": "°",
+            "is_day": "",
+            "weathercode": "wmo code"
+        },
+        "current_weather": {
+            "time": "2024-12-11T20:45",
+            "interval": 900,
+            "temperature": 0.6,
+            "windspeed": 8.4,
+            "winddirection": 313,
+            "is_day": 0,
+            "weathercode": 3
+        }
+    }
+}

--- a/data/current_weather.json
+++ b/data/current_weather.json
@@ -1,7 +1,7 @@
 {
     "latitude": 52.23009,
     "longitude": 21.017075,
-    "generationtime_ms": 0.0749826431274414,
+    "generationtime_ms": 0.04303455352783203,
     "utc_offset_seconds": 0,
     "timezone": "GMT",
     "timezone_abbreviation": "GMT",
@@ -16,11 +16,11 @@
         "weathercode": "wmo code"
     },
     "current_weather": {
-        "time": "2024-12-10T21:45",
+        "time": "2024-12-11T06:15",
         "interval": 900,
-        "temperature": 0.8,
-        "windspeed": 9.4,
-        "winddirection": 32,
+        "temperature": 0.4,
+        "windspeed": 6.5,
+        "winddirection": 341,
         "is_day": 0,
         "weathercode": 3
     }

--- a/data/historical_weather.json
+++ b/data/historical_weather.json
@@ -1,7 +1,7 @@
 {
     "latitude": 52.196835,
     "longitude": 21.08856,
-    "generationtime_ms": 0.053048133850097656,
+    "generationtime_ms": 0.04696846008300781,
     "utc_offset_seconds": 0,
     "timezone": "GMT",
     "timezone_abbreviation": "GMT",

--- a/fetchers/current_fetcher.py
+++ b/fetchers/current_fetcher.py
@@ -14,14 +14,14 @@ def get_city_coordinates(city_name: str) -> tuple[float, float]:
 
 
 def fetch_current_weather(
-        latitude: Optional[float],
-        longitude: Optional[float],
-        city_name: Optional[str]) -> Dict[str, Any]:
+        latitude: Optional[float] = None,
+        longitude: Optional[float] = None,
+        city_name: Optional[str] = None) -> Dict[str, Any]:
     """
     Fetch current weather data from Open-Meteo API.
     The function can be called by specifying either:
     - latitude and longitude directly, or
-    - a city_name present in the config.CITIES dictionary.
+    - a city_name present in the config. CITIES dictionary.
 
     :param latitude: Latitude of the desired location (if city_name not provided).
     :param longitude: Longitude of the desired location (if city_name not provided).
@@ -45,3 +45,25 @@ def fetch_current_weather(
     response = requests.get(url, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
+
+
+def get_city_weather(city_name: str) -> Dict[str, Any]:
+    """
+    Retrieve weather for a specific city by name.
+
+    :param city_name: Name of the city to fetch weather for.
+    :return: Dictionary with current weather data for the city.
+    """
+    return fetch_current_weather(city_name=city_name)
+
+
+def fetch_weather_for_all_cities() -> Dict[str, Dict[str, Any]]:
+    """
+    Fetch current weather data for all cities in the CITIES dictionary.
+
+    :return: Dictionary with city names as keys and their weather data as values.
+    """
+    return {
+        city: fetch_current_weather(city_name=city)
+        for city in CITIES.keys()
+    }

--- a/fetchers/historical_fetcher.py
+++ b/fetchers/historical_fetcher.py
@@ -54,3 +54,44 @@ def fetch_historical_weather(
     response = requests.get(url, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
+
+
+def get_city_historical_weather(
+        city_name: str,
+        start_date: str,
+        end_date: str
+) -> Dict[str, Any]:
+    """
+    Retrieve historical weather for a specific city by name.
+
+    :param city_name: Name of the city to fetch weather for.
+    :param start_date: Start date for historical data.
+    :param end_date: End date for historical data.
+    :return: Dictionary with historical weather data for the city.
+    """
+    return fetch_historical_weather(
+        city_name=city_name,
+        start_date=start_date,
+        end_date=end_date
+    )
+
+
+def fetch_historical_weather_for_all_cities(
+        start_date: str,
+        end_date: str
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Fetch historical weather data for all cities in the CITIES dictionary.
+
+    :param start_date: Start date for historical data.
+    :param end_date: End date for historical data.
+    :return: Dictionary with city names as keys and their historical weather data as values.
+    """
+    return {
+        city: fetch_historical_weather(
+            city_name=city,
+            start_date=start_date,
+            end_date=end_date
+        )
+        for city in CITIES.keys()
+    }

--- a/main.py
+++ b/main.py
@@ -1,28 +1,131 @@
-from typing import Dict, Any
-
-from fetchers.current_fetcher import fetch_current_weather
-from fetchers.historical_fetcher import fetch_historical_weather
+from typing import Dict, Any, Optional
+import typer
+from fetchers.current_fetcher import fetch_current_weather, fetch_weather_for_all_cities
+from fetchers.historical_fetcher import fetch_historical_weather, fetch_historical_weather_for_all_cities
 from utils.file_manager import save_data_to_file
 
+app = typer.Typer()
 
-def main() -> None:
-    # Przykładowe współrzędne Warszawy
-    latitude: float = 52.2297
-    longitude: float = 21.0122
 
-    # Pobieranie aktualnej pogody
-    current_weather: Dict[str, Any] = fetch_current_weather(latitude=latitude, longitude=longitude)
-    save_data_to_file(current_weather, "data/current_weather.json")
+@app.command()
+def fetch_current(
+        city: Optional[str] = typer.Option(
+            None, help="Name of the city to fetch current weather for."
+        ),
+        latitude: Optional[float] = typer.Option(
+            None, help="Latitude of the location."
+        ),
+        longitude: Optional[float] = typer.Option(
+            None, help="Longitude of the location."
+        ),
+        output: str = typer.Option(
+            "data/current_weather.json", help="Output file path for current weather data."
+        )
+) -> None:
+    """
+    Fetch current weather data for a specified city or coordinates and save to a JSON file.
+    """
+    try:
+        current_weather: Dict[str, Any] = fetch_current_weather(
+            city_name=city,
+            latitude=latitude,
+            longitude=longitude
+        )
+        save_data_to_file(current_weather, output)
+        if city:
+            typer.echo(f"Current weather for {city} saved successfully to {output}.")
+        else:
+            typer.echo(f"Current weather for coordinates ({latitude}, {longitude}) saved successfully to {output}.")
+    except (ValueError, KeyError, requests.HTTPError) as e:
+        typer.echo(f"Error fetching current weather: {e}", err=True)
 
-    # Pobieranie historycznej pogody (np. za 1 stycznia 2023)
-    historical_weather: Dict[str, Any] = fetch_historical_weather(
-        latitude=latitude,
-        longitude=longitude,
-        start_date="2023-01-01",
-        end_date="2023-01-02"
-    )
-    save_data_to_file(historical_weather, "data/historical_weather.json")
+
+@app.command()
+def fetch_historical(
+        city: Optional[str] = typer.Option(
+            None, help="Name of the city to fetch historical weather for."
+        ),
+        latitude: Optional[float] = typer.Option(
+            None, help="Latitude of the location."
+        ),
+        longitude: Optional[float] = typer.Option(
+            None, help="Longitude of the location."
+        ),
+        start_date: str = typer.Option(
+            ..., help="Start date for historical data in YYYY-MM-DD format."
+        ),
+        end_date: str = typer.Option(
+            ..., help="End date for historical data in YYYY-MM-DD format."
+        ),
+        output: str = typer.Option(
+            "data/historical_weather.json", help="Output file path for historical weather data."
+        )
+) -> None:
+    """
+    Fetch historical weather data for a specified city or coordinates and save to a JSON file.
+    """
+    try:
+        historical_weather: Dict[str, Any] = fetch_historical_weather(
+            city_name=city,
+            latitude=latitude,
+            longitude=longitude,
+            start_date=start_date,
+            end_date=end_date
+        )
+        save_data_to_file(historical_weather, output)
+        if city:
+            typer.echo(f"Historical weather for {city} from {start_date} to {end_date} saved successfully to {output}.")
+        else:
+            typer.echo(
+                f"Historical weather for coordinates ({latitude}, {longitude}) from {start_date} to {end_date} saved successfully to {output}.")
+    except (ValueError, KeyError, requests.HTTPError) as e:
+        typer.echo(f"Error fetching historical weather: {e}", err=True)
+
+
+@app.command()
+def fetch_current_all(
+        output: str = typer.Option(
+            "data/all_current_weather.json",
+            help="Output file path for all cities' current weather data."
+        )
+) -> None:
+    """
+    Fetch current weather data for all cities in the configuration and save to a JSON file.
+    """
+    try:
+        all_current_weather: Dict[str, Dict[str, Any]] = fetch_weather_for_all_cities()
+        save_data_to_file(all_current_weather, output)
+        typer.echo(f"Current weather for all cities saved successfully to {output}.")
+    except (ValueError, KeyError, requests.HTTPError) as e:
+        typer.echo(f"Error fetching current weather for all cities: {e}", err=True)
+
+
+@app.command()
+def fetch_historical_all(
+        start_date: str = typer.Option(
+            ..., help="Start date for historical data in YYYY-MM-DD format."
+        ),
+        end_date: str = typer.Option(
+            ..., help="End date for historical data in YYYY-MM-DD format."
+        ),
+        output: str = typer.Option(
+            "data/all_historical_weather.json",
+            help="Output file path for all cities' historical weather data."
+        )
+) -> None:
+    """
+    Fetch historical weather data for all cities in the configuration and save to a JSON file.
+    """
+    try:
+        all_historical_weather: Dict[str, Dict[str, Any]] = fetch_historical_weather_for_all_cities(
+            start_date=start_date,
+            end_date=end_date
+        )
+        save_data_to_file(all_historical_weather, output)
+        typer.echo(f"Historical weather for all cities from {start_date} to {end_date} saved successfully to {output}.")
+    except (ValueError, KeyError, requests.HTTPError) as e:
+        typer.echo(f"Error fetching historical weather for all cities: {e}", err=True)
 
 
 if __name__ == "__main__":
-    main()
+    app()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+typer

--- a/utils/file_manager.py
+++ b/utils/file_manager.py
@@ -2,6 +2,7 @@ from typing import Any, Dict
 import json
 import os
 
+
 def save_data_to_file(data: Dict[str, Any], file_path: str) -> None:
     """
     Save given data dictionary as JSON file to the specified file path.


### PR DESCRIPTION
…cities

This commit enhances the weather fetching functionality by:

- Adding two new fetch methods to retrieve weather data for all cities in the configuration
- Implemetning the CLI interface
- Improving modularity and flexibility of weather data retrieval

New features:
- `fetch_weather_for_all_cities()` method in current weather fetcher
- `fetch_historical_weather_for_all_cities()` method in historical weather fetcher
- CLI commands using Typer

Changes:
- Updated main.py
- Added import for new fetching methods